### PR TITLE
DOC: Clarify index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
   <p><li><a class="biglink" href="https://numpy.org/doc/stable/">Web</a></li></p>
   <p><li><a class="biglink" href="https://numpy.org/doc/stable/numpy-ref.pdf">Reference Guide PDF</a></li></p>
   <p><li><a class="biglink" href="https://numpy.org/doc/stable/numpy-user.pdf">User Guide PDF</a></li></p>
-  <p><li><a class="biglink" href="https://numpy.org/devdocs/">Latest (unstable) documentation</a></li></p>
+  <p><li><a class="biglink" href="https://numpy.org/devdocs/">Latest (development) documentation</a></li></p>
   <p><li><a class="biglink" href="/neps">NumPy Enhancement Proposals</a></li></p>
 </ul>
 <p>Versions:</p>

--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
 <html>
   <head>
     <meta charset="utf-8">
-    
+
     <title>NumPy Documentation</title>
-    
+
     <link rel="stylesheet" type="text/css" href="_static/css/spc-bootstrap.css">
     <link rel="stylesheet" type="text/css" href="_static/css/spc-extend.css">
     <link rel="stylesheet" href="_static/scipy.css" type="text/css" >
     <link rel="stylesheet" href="_static/pygments.css" type="text/css" >
     <link rel="stylesheet" href="_static/donation.css" type="text/css" >
-    
+
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
@@ -42,41 +42,40 @@
 
     <div class="container">
       <div class="main">
-        
+
 
 	<div class="row-fluid">
           <div class="span9">
-            
+
 	      <div class="row-fluid">
 		<div class="span9">
   		  <div class="spc-navbar">
-		    
+
     <ul class="nav nav-pills pull-left">
         <li class="active"><a href="http://numpy.org/">NumPy.org</a></li>
-	 
+
     </ul>
 		  </div>
 		</div>
 	      </div>
-            
+
         <div class="bodywrapper">
           <div class="body" id="spc-section-body">
-            
+
   <div class="section" id="numpy">
 <h1>NumPy Documentation</h1>
 <div class="toctree-wrapper compound">
 </div>
 <div class="section" id="documentation">
-<p>The most up-to-date NumPy documentation can be found at
-<a class="reference external" href="/devdocs">Latest (development) version</a>.
-It includes a user guide, full reference documentation, a developer guide, and
-meta information.</p>
-<p>Other links:</p>
 <ul class="simple">
-  <li>
-    <a class="biglink" href="/neps">NumPy Enhancement Proposals</a>
-       (which include the NumPy Roadmap and detailed plans for major new features).
-  </li>
+  <p><li><a class="biglink" href="https://numpy.org/doc/stable/">Web</a></li></p>
+  <p><li><a class="biglink" href="https://numpy.org/doc/stable/numpy-ref.pdf">Reference Guide PDF</a></li></p>
+  <p><li><a class="biglink" href="https://numpy.org/doc/stable/numpy-user.pdf">User Guide PDF</a></li></p>
+  <p><li><a class="biglink" href="https://numpy.org/devdocs/">Latest (unstable) documentation</a></li></p>
+  <p><li><a class="biglink" href="/neps">NumPy Enhancement Proposals</a></li></p>
+</ul>
+<p>Versions:</p>
+<ul class="simple">
   <!-- insert here -->
   <!--- tag v1.18.4 -->
   <li>
@@ -151,7 +150,7 @@ a.extlink:after {
 
     <div class="container container-navbar-bottom">
       <div class="spc-navbar">
-        
+
       </div>
     </div>
     <div class="container">
@@ -159,7 +158,7 @@ a.extlink:after {
     <div class="row-fluid">
     <ul class="inline pull-left">
       <li>
-        &copy; Copyright 2019 NumPy developers.
+        &copy; Copyright 2008-2020 NumPy. All rights reserved.
       </li>
     </ul>
     </div>


### PR DESCRIPTION
Explicit link to current stable docs, explicit links to its pdf.
Clarify that devdocs is unstable. Update copyright line.

<details><summary>New page</summary>

![image](https://user-images.githubusercontent.com/6691888/84593265-59aac280-ae19-11ea-99f2-611c25fa29a4.png)

</details>
