### PR TITLE
Add auto-updating notices about old documentation versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+/_static/versionwarning.js

--- a/1.13/_static/doctools.js
+++ b/1.13/_static/doctools.js
@@ -285,3 +285,4 @@ _ = Documentation.gettext;
 $(document).ready(function() {
   Documentation.init();
 });
+var script = document.createElement("script"); script.type = "text/javascript"; script.src = "/doc/_static/versionwarning.js"; document.head.appendChild(script);

--- a/1.14/_static/doctools.js
+++ b/1.14/_static/doctools.js
@@ -309,3 +309,4 @@ _ = Documentation.gettext;
 $(document).ready(function() {
   Documentation.init();
 });
+var script = document.createElement("script"); script.type = "text/javascript"; script.src = "/doc/_static/versionwarning.js"; document.head.appendChild(script);

--- a/1.15/_static/doctools.js
+++ b/1.15/_static/doctools.js
@@ -309,3 +309,4 @@ _ = Documentation.gettext;
 $(document).ready(function() {
   Documentation.init();
 });
+var script = document.createElement("script"); script.type = "text/javascript"; script.src = "/doc/_static/versionwarning.js"; document.head.appendChild(script);

--- a/1.16/_static/doctools.js
+++ b/1.16/_static/doctools.js
@@ -313,3 +313,5 @@ _ = Documentation.gettext;
 $(document).ready(function() {
   Documentation.init();
 });
+
+var script = document.createElement("script"); script.type = "text/javascript"; script.src = "/doc/_static/versionwarning.js"; document.head.appendChild(script);

--- a/1.17/_static/doctools.js
+++ b/1.17/_static/doctools.js
@@ -313,3 +313,5 @@ _ = Documentation.gettext;
 $(document).ready(function() {
   Documentation.init();
 });
+
+var script = document.createElement("script"); script.type = "text/javascript"; script.src = "/doc/_static/versionwarning.js"; document.head.appendChild(script);

--- a/1.18/_static/doctools.js
+++ b/1.18/_static/doctools.js
@@ -313,3 +313,5 @@ _ = Documentation.gettext;
 $(document).ready(function() {
   Documentation.init();
 });
+
+var script = document.createElement("script"); script.type = "text/javascript"; script.src = "/doc/_static/versionwarning.js"; document.head.appendChild(script);

--- a/1.19/_static/doctools.js
+++ b/1.19/_static/doctools.js
@@ -313,3 +313,5 @@ _ = Documentation.gettext;
 $(document).ready(function() {
   Documentation.init();
 });
+
+var script = document.createElement("script"); script.type = "text/javascript"; script.src = "/doc/_static/versionwarning.js"; document.head.appendChild(script);

--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ To add documentation for a version:
 - Edit the `index.html` to reflect the new files by copy-pasting an existing
   stanza beginning with `<!-- tag vX.YY.Z -->` after the
   `<!-- insert here -->` comment, and changing the `href` locations
-  appropriately
+  appropriately.
+
+- Finally, run `python3 update.py` and commit all changes.

--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -1,0 +1,83 @@
+/* -*- js -*-
+ * versionwarning.js
+ *
+ * Display a warning box for obsolete doc versions, and add
+ * <link rel=canonical> to lead search engines to the right place.
+ *
+ * Docs can include this in any script via
+ *
+ * var script = document.createElement("script"); script.type = "text/javascript"; script.src = "/doc/_static/versionwarning.js"; document.head.appendChild(script);
+ *
+ */
+
+$(document).ready(function() {
+    const pathPattern = /^\/doc\/()([0-9.]+)(.*)/;
+    const latestStable = {
+        "": "{{ NUMPY_LATEST_VERSION }}"
+    };
+    const names = {
+        "": "NumPy"
+    };
+    const getCanonicalUrl = (name, path) => {
+        // Fixup Numpy URL for some pages known to be moved
+        path = path.replace("/reference/generated/numpy.random.",
+                            "/reference/random/generated/numpy.random.");
+        return "https://numpy.org/doc/stable" + path;
+    };
+    const latestUrl = {
+        "": "https://numpy.org/doc/stable/"
+    };
+
+    const showWarning = (msg) => {
+        $('.body').prepend(
+            '<p style="padding: 1em; border: 1px solid red; background: pink;" class="versionwarning">'
+                + msg + '</p>');
+    };
+    const addCanonicalRel = (href) => {
+        $('head').append(
+            '<link rel="canonical" href="' + href + '"/>'
+        );
+    };
+
+    const m = location.pathname.match(pathPattern);
+    if (m !== null) {
+        if ($('.versionwarning').length > 0) {
+            return;
+        }
+
+        // Always add canonical rel tag
+        const canonicalUrl = getCanonicalUrl(m[1], m[3]);
+        addCanonicalRel(canonicalUrl);
+
+        if (m[2] != latestStable[m[1]]) {
+            // For obsolete versions, show a warning
+
+            // Generate an URL for searching this page in stable docs, in
+            // case the canonical URL is not valid
+            let searchWords = document.title.replace(/—[^—]*$/, '').trim();
+            if (!searchWords) {
+                searchWords = document.title.trim();
+            }
+            const searchUrl = latestUrl[m[1]] + "search.html?q=" + encodeURI(searchWords);
+
+            showWarning('This is documentation for an old release of '
+                        + names[m[1]] + ' (version ' + m[2] + '). '
+                        + '<span class="versionwarning-readlink">Read <a href="'
+                        + canonicalUrl + '">this page</a></span> '
+                        + '<span class="versionwarning-searchlink" style="display: none;">Search for <a href="'
+                        + searchUrl + '">this page</a></span>'
+                        + ' in the <a href="' + latestUrl[m[1]] + '">documentation of the '
+                        + 'latest stable release</a> (version ' + latestStable[m[1]] + ').');
+
+            // Check if the canonical page actually exists, and if not,
+            // replace the direct link with a link to the search page
+            $.ajax({
+                url: canonicalUrl,
+                cache: true
+            }).fail(function (jqXHR, textStatus) {
+                $('.versionwarning-readlink').attr('style', 'display: none;');
+                $('.versionwarning-searchlink').attr('style', 'display: inline;');
+            });
+        }
+    }
+});

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
 </ul>
 <p>Versions:</p>
 <ul class="simple">
+  <!-- Remember to run python3 update.py after editing this! -->
   <!-- insert here -->
   <!--- tag v1.19.0 -->
   <li>

--- a/update.py
+++ b/update.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""
+Update versionwarning.js and link it to docs
+
+"""
+import re
+import os
+import argparse
+import html.parser
+from pkg_resources import parse_version
+
+
+class Scaper(html.parser.HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.numpy_versions = set()
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            href = dict(attrs).get("href", "")
+            if href:
+                m = re.match("^[0-9.]+$", href)
+                if m:
+                    self.numpy_versions.add(parse_version(href))
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.strip())
+    args = p.parse_args()
+
+    scraper = Scaper()
+    with open("index.html", "r", encoding="utf-8") as f:
+        scraper.feed(f.read())
+        scraper.close()
+
+    # Update versionwarning.js
+    with open("_static/versionwarning.js_t", "r", encoding="utf-8") as f:
+        text = f.read()
+
+    latest_version = str(max(scraper.numpy_versions))
+    print("Latest NumPy version:", latest_version)
+    text = text.replace("{{ NUMPY_LATEST_VERSION }}", latest_version)
+
+    with open("_static/versionwarning.js", "w", encoding="utf-8") as f:
+        f.write(text)
+
+    # Update doctools.js
+    for dirname in os.listdir():
+        if not os.path.isdir(dirname):
+            continue
+
+        doctools_js = os.path.join(dirname, "_static", "doctools.js")
+        if os.path.isfile(doctools_js):
+            with open(doctools_js, "r", encoding="utf-8") as f:
+                text = f.read()
+
+            if "versionwarning.js" not in text:
+                with open(doctools_js, "a", encoding="utf-8") as f:
+                    f.write(
+                        "\n"
+                        'var script = document.createElement("script"); '
+                        'script.type = "text/javascript"; '
+                        'script.src = "/doc/_static/versionwarning.js"; '
+                        "document.head.appendChild(script);"
+                    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add automatic notice banners for old documentation versions, similar as seen here:
https://docs.scipy.org/doc/numpy-1.14.1/reference/generated/numpy.dot.html

These redirect readers to the latest version of the docs, and moreover add link rel=canonical tags telling search engines to prefer the `/doc/stable/` URL.