### PR TITLE
MAINT: mitigate version matching for 1.23

### DIFF
--- a/_static/versions.json
+++ b/_static/versions.json
@@ -6,13 +6,8 @@
     },
     {
         "name": "1.23 (stable)",
-        "version": "stable",
+        "version": "doc/1.23",
         "url": "https://numpy.org/doc/stable/"
-    },
-    {
-        "name": "1.23",
-        "version": "1.23",
-        "url": "https://numpy.org/doc/1.23/"
     },
     {
         "name": "1.22",


### PR DESCRIPTION
Currently, release build have a version identifier set to `doc/{version}`. See https://github.com/numpy/numpy/blob/main/doc/source/conf.py. This has no match in the switcher file `versions.json`.

This PR mitigates the issue by adding the correct match for the current release: `doc/1.23`.
Moving forward, `conf.py` can either be modifier to remove the prefix `doc/` or next releases would need to maintain the prefix `doc/`.

Also note that css colours are matched agains the `name`. If name does not contain `stable`, it will be associated as an old release and the button will be red. (Development version is orange because it matches `name="dev"`, same kind of logic for PRs)
