### PR TITLE
Update building.html

### DIFF
--- a/1.24/user/building.html
+++ b/1.24/user/building.html
@@ -487,7 +487,7 @@ the correct development environment right in your browser, reducing the need to
 install local development environments and deal with incompatible dependencies.</p>
 <p>If you are a Windows user, unfamiliar with using the command line or building
 NumPy for the first time, it is often faster to build with Gitpod. Here are the
-in-depth instructions for building NumPy with <a class="reference external" href="https://numpy.org/devdocs/dev/development_gitpod.html">building NumPy with Gitpod</a>.</p>
+in-depth instructions for building NumPy with <a class="reference external" href="https://numpy.org/doc/stable/dev/development_gitpod.html ">building NumPy with Gitpod</a>.</p>
 </section>
 <section id="building-locally">
 <h2>Building locally<a class="headerlink" href="#building-locally" title="Permalink to this heading">#</a></h2>


### PR DESCRIPTION
issue #23786:Link to gitpod instruction on stable docs points to devdocs, leads to 404

Issue URL: https://github.com/numpy/numpy/issues/23786

In this commit, the link for gitpod build has been changed from https://numpy.org/devdocs/dev/development_gitpod.html  to https://numpy.org/doc/stable/dev/development_gitpod.html.