### PR TITLE
Updated building.html

### DIFF
--- a/1.24/user/building.html
+++ b/1.24/user/building.html
@@ -378,6 +378,9 @@ function checkPageExistsAndRedirect(event) {
 <nav id="bd-toc-nav">
     <ul class="visible nav section-nav flex-column">
  <li class="toc-h2 nav-item toc-entry">
+    <a class="reference internal nav-link" href="#Codespaces">
+   Codespaces
+  </a>
   <a class="reference internal nav-link" href="#gitpod">
    Gitpod
   </a>
@@ -477,9 +480,16 @@ function checkPageExistsAndRedirect(event) {
                 
   <section id="building-from-source">
 <span id="id1"></span><h1>Building from source<a class="headerlink" href="#building-from-source" title="Permalink to this heading">#</a></h1>
-<p>There are two options for building NumPy- building with Gitpod or locally from
+<p>There are two options for building NumPy- building with Codespaces or locally from
 source. Your choice depends on your operating system and familiarity with the
 command line.</p>
+ <section id="Codespaces"> 
+<h2>Codespaces<a class="headerlink" href="#Codespaces" title="Permalink to this heading">#</a></h2>
+<p>When you have reliable internet connectivity and are in need of a temporary setup, opting to work on NumPy within a Codespaces environment can significantly expedite your workflow. Codespaces effortlessly creates the correct development environment directly within your browser, eliminating the necessity to install local development environments and navigate through the challenges of managing incompatible dependencies</p>
+<p>It might be easier to build with a cloud-based
+environment. These change with the times, here is our 
+<a class="reference external" href="https://numpy.org/devdocs/dev/development_environment.html#recommended-development-setup">most recent suggestion</a>.</p>
+</section>
 <section id="gitpod">
 <h2>Gitpod<a class="headerlink" href="#gitpod" title="Permalink to this heading">#</a></h2>
 <p>Gitpod is an open-source platform that automatically creates
@@ -489,6 +499,7 @@ install local development environments and deal with incompatible dependencies.<
 NumPy for the first time, it is often faster to build with Gitpod. Here are the
 in-depth instructions for building NumPy with <a class="reference external" href="https://numpy.org/devdocs/dev/development_gitpod.html">building NumPy with Gitpod</a>.</p>
 </section>
+<p><span class="versionmodified deprecated">Deprecated since version 1.24: </span>The Gitpod instance is no longer maintained </p>
 <section id="building-locally">
 <h2>Building locally<a class="headerlink" href="#building-locally" title="Permalink to this heading">#</a></h2>
 <p>Building locally on your machine gives you


### PR DESCRIPTION
issue #23786:Link to gitpod instruction on stable docs points to devdocs, leads to 404

Issue URL: numpy/numpy#23786

### **I have updated the following changes**

1.documentation for the Codespaces environment for building the NumPy project.
2.deprecated note for the gitpod section.