### PR TITLE
update update.py to use packaging.version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ To add documentation for a version:
   `<!-- insert here -->` comment, and changing the `href` locations
   appropriately.
 
-- Finally, run `python3 update.py` and commit all changes.
+- Finally, run `pip install packaging; python3 update.py` and commit all changes.

--- a/update.py
+++ b/update.py
@@ -7,7 +7,7 @@ import re
 import os
 import argparse
 import html.parser
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 
 class Scaper(html.parser.HTMLParser):


### PR DESCRIPTION
Fixes numpy/numpy#24724

pkg_resources, which comes from setuptools, no longer can be used to get `parse_version`. Use the one from packaging instead