### PR TITLE
fix version pulldown for 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,6 @@ To add documentation for a version:
   `<!-- insert here -->` comment, and changing the `href` locations
   appropriately.
 
+- Edit the `_static/versions.json` to reflect the new version.
+
 - Finally, run `pip install packaging; python3 update.py` and commit all changes.

--- a/_static/versions.json
+++ b/_static/versions.json
@@ -12,7 +12,7 @@
     {
         "name": "1.25",
         "version": "doc/1.25",
-        "url": "https://numpy.org/doc/stable/"
+        "url": "https://numpy.org/doc/1.25/"
     },
     {
         "name": "1.24",


### PR DESCRIPTION
The version pulldown at https://numpy.org/doc/stable/index.html points both "1.26" and "1.25" to the "stable" docs. This is a minimal fix. Additionally, the 1.26 reference is to "stable", shouldn't we add a new "stable" entry and point 1.26 to "1.26" instead?