### PR TITLE
fix v1.26 reference/generated/numpy.vectorize.html

### DIFF
--- a/1.25/reference/generated/numpy.vectorize.html
+++ b/1.25/reference/generated/numpy.vectorize.html
@@ -676,19 +676,20 @@ vectorized calculation of Pearson correlation coefficient and its p-value:</p>
 </div>
 <p>Decorator syntax is supported.  The decorator can be called as
 a function to provide keyword arguments.
-&gt;&gt;&gt;&#64;np.vectorize
-…def identity(x):
-…    return x
-…
-&gt;&gt;&gt;identity([0, 1, 2])
-array([0, 1, 2])
-&gt;&gt;&gt;&#64;np.vectorize(otypes=[float])
-…def as_float(x):
-…    return x
-…
-&gt;&gt;&gt;as_float([0, 1, 2])
-array([0., 1., 2.])</p>
-<p class="rubric">Methods</p>
+<div class="doctest highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="nd">@np</span><span class="o">.</span><span class="n">vectorize</span>
+<span class="gp">... </span><span class="k">def</span> <span class="nf">identity</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+<span class="gp">... </span>    <span class="k">return</span> <span class="n">x</span>
+<span class="gp">...</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">identity</span><span class="p">([</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">])</span>
+<span class="go">array([0, 1, 2])</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="nd">@np</span><span class="o">.</span><span class="n">vectorize</span><span class="p">(</span><span class="n">otypes</span><span class="o">=</span><span class="p">[</span><span class="nb">float</span><span class="p">])</span>
+<span class="gp">... </span><span class="k">def</span> <span class="nf">as_float</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+<span class="gp">... </span>    <span class="k">return</span> <span class="n">x</span>
+<span class="gp">...</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">as_float</span><span class="p">([</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">])</span>
+<span class="go">array([0., 1., 2.])</span>
+</pre></div>
+</div><p class="rubric">Methods</p>
 <table class="autosummary longtable table autosummary">
 <tbody>
 <tr class="row-odd"><td><p><a class="reference internal" href="numpy.vectorize.__call__.html#numpy.vectorize.__call__" title="numpy.vectorize.__call__"><code class="xref py py-obj docutils literal notranslate"><span class="pre">__call__</span></code></a>(*args, **kwargs)</p></td>

--- a/1.26/reference/generated/numpy.vectorize.html
+++ b/1.26/reference/generated/numpy.vectorize.html
@@ -783,19 +783,20 @@ vectorized calculation of Pearson correlation coefficient and its p-value:</p>
 </div>
 <p>Decorator syntax is supported.  The decorator can be called as
 a function to provide keyword arguments.
-&gt;&gt;&gt;&#64;np.vectorize
-…def identity(x):
-…    return x
-…
-&gt;&gt;&gt;identity([0, 1, 2])
-array([0, 1, 2])
-&gt;&gt;&gt;&#64;np.vectorize(otypes=[float])
-…def as_float(x):
-…    return x
-…
-&gt;&gt;&gt;as_float([0, 1, 2])
-array([0., 1., 2.])</p>
-<p class="rubric">Methods</p>
+<div class="doctest highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="nd">@np</span><span class="o">.</span><span class="n">vectorize</span>
+<span class="gp">... </span><span class="k">def</span> <span class="nf">identity</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+<span class="gp">... </span>    <span class="k">return</span> <span class="n">x</span>
+<span class="gp">...</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">identity</span><span class="p">([</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">])</span>
+<span class="go">array([0, 1, 2])</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="nd">@np</span><span class="o">.</span><span class="n">vectorize</span><span class="p">(</span><span class="n">otypes</span><span class="o">=</span><span class="p">[</span><span class="nb">float</span><span class="p">])</span>
+<span class="gp">... </span><span class="k">def</span> <span class="nf">as_float</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+<span class="gp">... </span>    <span class="k">return</span> <span class="n">x</span>
+<span class="gp">...</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">as_float</span><span class="p">([</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">])</span>
+<span class="go">array([0., 1., 2.])</span>
+</pre></div>
+</div><p class="rubric">Methods</p>
 <table class="autosummary longtable table autosummary">
 <tbody>
 <tr class="row-odd"><td><p><a class="reference internal" href="numpy.vectorize.__call__.html#numpy.vectorize.__call__" title="numpy.vectorize.__call__"><code class="xref py py-obj docutils literal notranslate"><span class="pre">__call__</span></code></a>(*args, **kwargs)</p></td>


### PR DESCRIPTION
Manually edit the HTML to fix rendering of [12.6 numpy.vectorize](https://numpy.org/doc/1.26/reference/generated/numpy.vectorize.html) (the last example) and likewise 1.25 numpy.vectorize.

I verified locally this is correct, and will submit a PR to the maintenance/1.26.x branch.

xref numpy/numpy#26600