### PR TITLE
fix version.json version to match generated documentation version

### DIFF
--- a/_static/versions.json
+++ b/_static/versions.json
@@ -6,7 +6,7 @@
     },
     {
         "name": "2.0 (stable)",
-        "version": "doc/2.0",
+        "version": "2.0",
         "url": "https://numpy.org/doc/stable/",
         "preferred": true
     },


### PR DESCRIPTION
The format has changed with the new data theme version switcher.