### PR TITLE
comment out version-switcher color

### DIFF
--- a/2.0/_static/numpy.css
+++ b/2.0/_static/numpy.css
@@ -27,12 +27,12 @@ body {
   opacity: 0.9;
 }
 
-.version-switcher__button:not([data-active-version-name*="stable"]):not([data-active-version-name*="dev"]):not([data-active-version-name*="pull"]) {
+/* .version-switcher__button:not([data-active-version-name*="stable"]):not([data-active-version-name*="dev"]):not([data-active-version-name*="pull"]) {
   background-color: var(--pst-color-danger);
   border-color: var(--pst-color-danger);
   opacity: 0.9;
 }
-
+*/
 .version-switcher__menu a.list-group-item {
   font-size: small;
 }


### PR DESCRIPTION
Comment out the css styling that is making the 2.0 version red in the version pulldown