### PR TITLE
Clarifify use of standard deviation in numpy.random.normal.html

### DIFF
--- a/1.13/reference/generated/numpy.random.normal.html
+++ b/1.13/reference/generated/numpy.random.normal.html
@@ -181,7 +181,7 @@ pp. 51, 51, 125.</td></tr>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">s</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">normal</span><span class="p">(</span><span class="n">mu</span><span class="p">,</span> <span class="n">sigma</span><span class="p">,</span> <span class="mi">1000</span><span class="p">)</span>
 </pre></div>
 </div>
-<p>Verify the mean and the variance:</p>
+<p>Verify the mean and the standard deviation:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="nb">abs</span><span class="p">(</span><span class="n">mu</span> <span class="o">-</span> <span class="n">np</span><span class="o">.</span><span class="n">mean</span><span class="p">(</span><span class="n">s</span><span class="p">))</span> <span class="o">&lt;</span> <span class="mf">0.01</span>
 <span class="go">True</span>
 </pre></div>


### PR DESCRIPTION
Previous texts mistakenly referred to the value as variance. Updated them to correctly reflect that standard deviation is being used. Removes confusion.