### PR TITLE
Remove the link to the pdf version of NumPy v1.24 docs

### DIFF
--- a/1.24/index.html
+++ b/1.24/index.html
@@ -286,7 +286,6 @@ function checkPageExistsAndRedirect(event) {
 </div>
 <p><strong>Version</strong>: 1.24</p>
 <p><strong>Download documentation</strong>:
-<a class="reference external" href="https://numpy.org/doc/stable/numpy-user.pdf">PDF Version</a> |
 <a class="reference external" href="https://numpy.org/doc/">Historical versions of documentation</a></p>
 <p><strong>Useful links</strong>:
 <a class="reference external" href="https://numpy.org/install/">Installation</a> |


### PR DESCRIPTION
Removing the link to the pdf version as NumPy v1.24 didn't have the documentation released in a .pdf format.

Resolves https://github.com/numpy/numpy.org/issues/643
