### PR TITLE
Update links to PDF versions of NumPy v1.22 and v1.23 User Guides

### DIFF
--- a/1.22/index.html
+++ b/1.22/index.html
@@ -186,7 +186,7 @@
 </div>
 <p><strong>Version</strong>: 1.22</p>
 <p><strong>Download documentation</strong>:
-<a class="reference external" href="https://numpy.org/doc/stable/numpy-user.pdf">PDF Version</a> |
+<a class="reference external" href="https://numpy.org/doc/1.22/numpy-user.pdf">PDF Version</a> |
 <a class="reference external" href="https://numpy.org/doc/">Historical versions of documentation</a></p>
 <p><strong>Useful links</strong>:
 <a class="reference external" href="https://numpy.org/install/">Installation</a> |

--- a/1.23/index.html
+++ b/1.23/index.html
@@ -263,7 +263,7 @@ function checkPageExistsAndRedirect(event) {
 </div>
 <p><strong>Version</strong>: 1.23</p>
 <p><strong>Download documentation</strong>:
-<a class="reference external" href="https://numpy.org/doc/stable/numpy-user.pdf">PDF Version</a> |
+<a class="reference external" href="https://numpy.org/doc/1.23/numpy-user.pdf">PDF Version</a> |
 <a class="reference external" href="https://numpy.org/doc/">Historical versions of documentation</a></p>
 <p><strong>Useful links</strong>:
 <a class="reference external" href="https://numpy.org/install/">Installation</a> |


### PR DESCRIPTION
Updates the links to the PDF versions of the NumPy v1.22 and v1.23 User Guides

Addresses https://github.com/numpy/numpy.org/issues/643#issuecomment-1594133664

