### PR TITLE
fix howto-docs.html pages for bad doxygen rendering on versions 2.0-2.3

### DIFF
--- a/2.0/dev/howto-docs.html
+++ b/2.0/dev/howto-docs.html
@@ -694,17 +694,24 @@ existing non-indexed comment blocks.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenfunction: Unable to resolve function “doxy_javadoc_example” with arguments None in doxygen xml output for project “numpy” from directory: ../build/doxygen/xml.
-Potential matches:
-</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">-</span> <span class="nb">int</span> <span class="n">doxy_javadoc_example</span><span class="p">(</span><span class="nb">int</span> <span class="n">num</span><span class="p">,</span> <span class="n">const</span> <span class="n">char</span> <span class="o">*</span><span class="nb">str</span><span class="p">)</span>
-<span class="o">-</span> <span class="nb">int</span> <span class="n">doxy_javadoc_example</span><span class="p">(</span><span class="nb">int</span> <span class="n">num</span><span class="p">,</span> <span class="n">const</span> <span class="n">char</span> <span class="o">*</span><span class="nb">str</span><span class="p">)</span>
-<span class="o">-</span> <span class="nb">int</span> <span class="n">doxy_javadoc_example</span><span class="p">(</span><span class="nb">int</span> <span class="n">num</span><span class="p">,</span> <span class="n">const</span> <span class="n">char</span> <span class="o">*</span><span class="nb">str</span><span class="p">)</span>
-</pre></div>
-</div>
-</div>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv420doxy_javadoc_exampleiPKc">
+<span id="_CPPv320doxy_javadoc_exampleiPKc"></span><span id="_CPPv220doxy_javadoc_exampleiPKc"></span><span id="doxy_javadoc_example__i.cCP"></span><span class="target" id="doxy__func_8h_1a4d3bfb60ef84efac3a58233ab1211795"></span><span class="kt"><span class="pre">int</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">doxy_javadoc_example</span></span></span><span class="sig-paren">(</span><span class="kt"><span class="pre">int</span></span><span class="w"> </span><span class="n sig-param"><span class="pre">num</span></span>, <span class="k"><span class="pre">const</span></span><span class="w"> </span><span class="kt"><span class="pre">char</span></span><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="n sig-param"><span class="pre">str</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv420doxy_javadoc_exampleiPKc" title="Link to this definition">#</a><br /></dt>
+<dd><p>This a simple brief. </p>
+<p>And the details goes here. Multi lines are welcome.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>num</strong> – leave a comment for parameter num. </p></li>
+<li><p><strong>str</strong> – leave a comment for the second parameter. </p></li>
+</ul>
+</dd>
+<dt class="field-even">Returns<span class="colon">:</span></dt>
+<dd class="field-even"><p>leave a comment for the returned value. </p>
+</dd>
+</dl>
+</dd></dl>
+
 <p><strong>For line comment, you can use a triple forward slash. For example</strong>:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">/**</span>
  <span class="o">*</span>  <span class="n">Template</span> <span class="n">to</span> <span class="n">represent</span> <span class="n">limbo</span> <span class="n">numbers</span><span class="o">.</span>
@@ -716,7 +723,7 @@ Potential matches:
  <span class="o">*</span>  <span class="nd">@param</span> <span class="n">N</span>  <span class="n">Number</span> <span class="n">of</span> <span class="n">elements</span><span class="o">.</span>
 <span class="o">*/</span>
 <span class="n">template</span><span class="o">&lt;</span><span class="n">typename</span> <span class="n">Tp</span><span class="p">,</span> <span class="n">std</span><span class="p">::</span><span class="n">size_t</span> <span class="n">N</span><span class="o">&gt;</span>
-<span class="k">class</span> <span class="nc">DoxyLimbo</span> <span class="p">{</span>
+<span class="k">class</span><span class="w"> </span><span class="nc">DoxyLimbo</span> <span class="p">{</span>
  <span class="n">public</span><span class="p">:</span>
     <span class="o">///</span> <span class="n">Default</span> <span class="n">constructor</span><span class="o">.</span> <span class="n">Initialize</span> <span class="n">nothing</span><span class="o">.</span>
     <span class="n">DoxyLimbo</span><span class="p">();</span>
@@ -763,48 +770,12 @@ Potential matches:
 <dd><p>Returns the raw data for the limbo. </p>
 </dd></dl>
 
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a9b76dccbb1e8dbbbb46a2f0dbe8909e0"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Default constructor. Initialize nothing. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1ae0090b4f0dda7e97c44a4d2a5fac7786"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE" title="DoxyLimbo::DoxyLimbo"><span class="n"><span class="pre">DoxyLimbo</span></span></a><span class="p"><span class="pre">&lt;</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="p"><span class="pre">,</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">&gt;</span></span><span class="w"> </span><span class="p"><span class="pre">&amp;</span></span><span class="n sig-param"><span class="pre">l</span></span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Set Default behavior for copy the limbo. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a7a413dc51bfa468b1958762d17615c81"></span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="sig-name descname"><span class="n"><span class="pre">data</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Returns the raw data for the limbo. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a9b76dccbb1e8dbbbb46a2f0dbe8909e0"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Default constructor. Initialize nothing. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1ae0090b4f0dda7e97c44a4d2a5fac7786"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE" title="DoxyLimbo::DoxyLimbo"><span class="n"><span class="pre">DoxyLimbo</span></span></a><span class="p"><span class="pre">&lt;</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="p"><span class="pre">,</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">&gt;</span></span><span class="w"> </span><span class="p"><span class="pre">&amp;</span></span><span class="n sig-param"><span class="pre">l</span></span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Set Default behavior for copy the limbo. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a7a413dc51bfa468b1958762d17615c81"></span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="sig-name descname"><span class="n"><span class="pre">data</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Returns the raw data for the limbo. </p>
-</dd></dl>
-
 </div>
 <div class="breathe-sectiondef docutils container">
 <p class="breathe-sectiondef-title rubric" id="breathe-section-title-protected-attributes">Protected Attributes</p>
 <dl class="cpp var">
 <dt class="sig sig-object cpp" id="_CPPv4N9DoxyLimbo6p_dataE">
-<span id="_CPPv3N9DoxyLimbo6p_dataE"></span><span id="_CPPv2N9DoxyLimbo6p_dataE"></span><span id="DoxyLimbo::p_data__TpA"></span><span class="target" id="classDoxyLimbo_1a952dd83b3eeb92013adcf2c065a98b77"></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">p_data</span></span></span><span class="p"><span class="pre">[</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">]</span></span><a class="headerlink" href="#_CPPv4N9DoxyLimbo6p_dataE" title="Link to this definition">#</a><br /></dt>
+<span id="_CPPv3N9DoxyLimbo6p_dataE"></span><span id="_CPPv2N9DoxyLimbo6p_dataE"></span><span id="DoxyLimbo::p_data__TpA"></span><span class="target" id="classDoxyLimbo_1a097c2d3d62ef8696ca0f4f9af875be48"></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">p_data</span></span></span><span class="p"><span class="pre">[</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">]</span></span><a class="headerlink" href="#_CPPv4N9DoxyLimbo6p_dataE" title="Link to this definition">#</a><br /></dt>
 <dd><p>Example for inline comment. </p>
 </dd></dl>
 
@@ -861,17 +832,23 @@ It is interpreted as source code.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenfunction: Unable to resolve function “doxy_reST_example” with arguments None in doxygen xml output for project “numpy” from directory: ../build/doxygen/xml.
-Potential matches:
-</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">-</span> <span class="n">void</span> <span class="n">doxy_reST_example</span><span class="p">(</span><span class="n">void</span><span class="p">)</span>
-<span class="o">-</span> <span class="n">void</span> <span class="n">doxy_reST_example</span><span class="p">(</span><span class="n">void</span><span class="p">)</span>
-<span class="o">-</span> <span class="n">void</span> <span class="n">doxy_reST_example</span><span class="p">(</span><span class="n">void</span><span class="p">)</span>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv417doxy_reST_examplev">
+<span id="_CPPv317doxy_reST_examplev"></span><span id="_CPPv217doxy_reST_examplev"></span><span id="doxy_reST_example__void"></span><span class="target" id="doxy__rst_8h_1a233bf6c1f71e836f3e5b8bd078ca12ec"></span><span class="kt"><span class="pre">void</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">doxy_reST_example</span></span></span><span class="sig-paren">(</span><span class="kt"><span class="pre">void</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv417doxy_reST_examplev" title="Link to this definition">#</a><br /></dt>
+<dd><p>A comment block contains reST markup. </p>
+<p><p>Some code example:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="nb">int</span> <span class="n">example</span><span class="p">(</span><span class="nb">int</span> <span class="n">x</span><span class="p">)</span> <span class="p">{</span>
+    <span class="k">return</span> <span class="n">x</span> <span class="o">*</span> <span class="mi">2</span><span class="p">;</span>
+<span class="p">}</span>
 </pre></div>
 </div>
+</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Thanks to <a class="reference external" href="https://breathe.readthedocs.io/en/latest/">Breathe</a>, we were able to bring it to <a class="reference external" href="https://www.doxygen.nl/index.html">Doxygen</a></p>
 </div>
+</dd></dl>
+
 </section>
 </section>
 <section id="feeding-doxygen">
@@ -927,7 +904,7 @@ to see it in action.</p>
 It takes the standard project, path, outline and no-link options and
 additionally the members, protected-members, private-members, undoc-members,
 membergroups and members-only options:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">..</span> <span class="n">doxygenclass</span><span class="p">::</span> <span class="o">&lt;</span><span class="k">class</span> <span class="nc">name</span><span class="o">&gt;</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">..</span> <span class="n">doxygenclass</span><span class="p">::</span> <span class="o">&lt;</span><span class="k">class</span><span class="w"> </span><span class="nc">name</span><span class="o">&gt;</span>
    <span class="p">:</span><span class="n">members</span><span class="p">:</span> <span class="p">[</span><span class="o">...</span><span class="p">]</span>
    <span class="p">:</span><span class="n">protected</span><span class="o">-</span><span class="n">members</span><span class="p">:</span>
    <span class="p">:</span><span class="n">private</span><span class="o">-</span><span class="n">members</span><span class="p">:</span>

--- a/2.1/dev/howto-docs.html
+++ b/2.1/dev/howto-docs.html
@@ -699,16 +699,24 @@ existing non-indexed comment blocks.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenfunction: Unable to resolve function “doxy_javadoc_example” with arguments None in doxygen xml output for project “numpy” from directory: ../build/doxygen/xml.
-Potential matches:
-</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">-</span> <span class="nb">int</span> <span class="n">doxy_javadoc_example</span><span class="p">(</span><span class="nb">int</span> <span class="n">num</span><span class="p">,</span> <span class="n">const</span> <span class="n">char</span> <span class="o">*</span><span class="nb">str</span><span class="p">)</span>
-<span class="o">-</span> <span class="nb">int</span> <span class="n">doxy_javadoc_example</span><span class="p">(</span><span class="nb">int</span> <span class="n">num</span><span class="p">,</span> <span class="n">const</span> <span class="n">char</span> <span class="o">*</span><span class="nb">str</span><span class="p">)</span>
-</pre></div>
-</div>
-</div>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv420doxy_javadoc_exampleiPKc">
+<span id="_CPPv320doxy_javadoc_exampleiPKc"></span><span id="_CPPv220doxy_javadoc_exampleiPKc"></span><span id="doxy_javadoc_example__i.cCP"></span><span class="target" id="doxy__func_8h_1a4d3bfb60ef84efac3a58233ab1211795"></span><span class="kt"><span class="pre">int</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">doxy_javadoc_example</span></span></span><span class="sig-paren">(</span><span class="kt"><span class="pre">int</span></span><span class="w"> </span><span class="n sig-param"><span class="pre">num</span></span>, <span class="k"><span class="pre">const</span></span><span class="w"> </span><span class="kt"><span class="pre">char</span></span><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="n sig-param"><span class="pre">str</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv420doxy_javadoc_exampleiPKc" title="Link to this definition">#</a><br /></dt>
+<dd><p>This a simple brief. </p>
+<p>And the details goes here. Multi lines are welcome.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>num</strong> – leave a comment for parameter num. </p></li>
+<li><p><strong>str</strong> – leave a comment for the second parameter. </p></li>
+</ul>
+</dd>
+<dt class="field-even">Returns<span class="colon">:</span></dt>
+<dd class="field-even"><p>leave a comment for the returned value. </p>
+</dd>
+</dl>
+</dd></dl>
+
 <p><strong>For line comment, you can use a triple forward slash. For example</strong>:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">/**</span>
  <span class="o">*</span>  <span class="n">Template</span> <span class="n">to</span> <span class="n">represent</span> <span class="n">limbo</span> <span class="n">numbers</span><span class="o">.</span>
@@ -720,7 +728,7 @@ Potential matches:
  <span class="o">*</span>  <span class="nd">@param</span> <span class="n">N</span>  <span class="n">Number</span> <span class="n">of</span> <span class="n">elements</span><span class="o">.</span>
 <span class="o">*/</span>
 <span class="n">template</span><span class="o">&lt;</span><span class="n">typename</span> <span class="n">Tp</span><span class="p">,</span> <span class="n">std</span><span class="p">::</span><span class="n">size_t</span> <span class="n">N</span><span class="o">&gt;</span>
-<span class="k">class</span> <span class="nc">DoxyLimbo</span> <span class="p">{</span>
+<span class="k">class</span><span class="w"> </span><span class="nc">DoxyLimbo</span> <span class="p">{</span>
  <span class="n">public</span><span class="p">:</span>
     <span class="o">///</span> <span class="n">Default</span> <span class="n">constructor</span><span class="o">.</span> <span class="n">Initialize</span> <span class="n">nothing</span><span class="o">.</span>
     <span class="n">DoxyLimbo</span><span class="p">();</span>
@@ -763,25 +771,7 @@ Potential matches:
 
 <dl class="cpp function">
 <dt class="sig sig-object cpp" id="_CPPv4N9DoxyLimbo4dataEv">
-<span id="_CPPv3N9DoxyLimbo4dataEv"></span><span id="_CPPv2N9DoxyLimbo4dataEv"></span><span id="DoxyLimbo::data"></span><span class="target" id="classDoxyLimbo_1a5e3d991177cab7f703a585f8895c3f5a"></span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="sig-name descname"><span class="n"><span class="pre">data</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv4N9DoxyLimbo4dataEv" title="Link to this definition">#</a><br /></dt>
-<dd><p>Returns the raw data for the limbo. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a9b76dccbb1e8dbbbb46a2f0dbe8909e0"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Default constructor. Initialize nothing. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1ae0090b4f0dda7e97c44a4d2a5fac7786"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE" title="DoxyLimbo::DoxyLimbo"><span class="n"><span class="pre">DoxyLimbo</span></span></a><span class="p"><span class="pre">&lt;</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="p"><span class="pre">,</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">&gt;</span></span><span class="w"> </span><span class="p"><span class="pre">&amp;</span></span><span class="n sig-param"><span class="pre">l</span></span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Set Default behavior for copy the limbo. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a5e3d991177cab7f703a585f8895c3f5a"></span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="sig-name descname"><span class="n"><span class="pre">data</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
+<span id="_CPPv3N9DoxyLimbo4dataEv"></span><span id="_CPPv2N9DoxyLimbo4dataEv"></span><span id="DoxyLimbo::data"></span><span class="target" id="classDoxyLimbo_1a7a413dc51bfa468b1958762d17615c81"></span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="sig-name descname"><span class="n"><span class="pre">data</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv4N9DoxyLimbo4dataEv" title="Link to this definition">#</a><br /></dt>
 <dd><p>Returns the raw data for the limbo. </p>
 </dd></dl>
 
@@ -790,7 +780,7 @@ Potential matches:
 <p class="breathe-sectiondef-title rubric" id="breathe-section-title-protected-attributes">Protected Attributes</p>
 <dl class="cpp var">
 <dt class="sig sig-object cpp" id="_CPPv4N9DoxyLimbo6p_dataE">
-<span id="_CPPv3N9DoxyLimbo6p_dataE"></span><span id="_CPPv2N9DoxyLimbo6p_dataE"></span><span id="DoxyLimbo::p_data__TpA"></span><span class="target" id="classDoxyLimbo_1a952dd83b3eeb92013adcf2c065a98b77"></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">p_data</span></span></span><span class="p"><span class="pre">[</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">]</span></span><a class="headerlink" href="#_CPPv4N9DoxyLimbo6p_dataE" title="Link to this definition">#</a><br /></dt>
+<span id="_CPPv3N9DoxyLimbo6p_dataE"></span><span id="_CPPv2N9DoxyLimbo6p_dataE"></span><span id="DoxyLimbo::p_data__TpA"></span><span class="target" id="classDoxyLimbo_1a097c2d3d62ef8696ca0f4f9af875be48"></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">p_data</span></span></span><span class="p"><span class="pre">[</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">]</span></span><a class="headerlink" href="#_CPPv4N9DoxyLimbo6p_dataE" title="Link to this definition">#</a><br /></dt>
 <dd><p>Example for inline comment. </p>
 </dd></dl>
 
@@ -847,16 +837,23 @@ It is interpreted as source code.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenfunction: Unable to resolve function “doxy_reST_example” with arguments None in doxygen xml output for project “numpy” from directory: ../build/doxygen/xml.
-Potential matches:
-</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">-</span> <span class="n">void</span> <span class="n">doxy_reST_example</span><span class="p">(</span><span class="n">void</span><span class="p">)</span>
-<span class="o">-</span> <span class="n">void</span> <span class="n">doxy_reST_example</span><span class="p">(</span><span class="n">void</span><span class="p">)</span>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv417doxy_reST_examplev">
+<span id="_CPPv317doxy_reST_examplev"></span><span id="_CPPv217doxy_reST_examplev"></span><span id="doxy_reST_example__void"></span><span class="target" id="doxy__rst_8h_1a233bf6c1f71e836f3e5b8bd078ca12ec"></span><span class="kt"><span class="pre">void</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">doxy_reST_example</span></span></span><span class="sig-paren">(</span><span class="kt"><span class="pre">void</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv417doxy_reST_examplev" title="Link to this definition">#</a><br /></dt>
+<dd><p>A comment block contains reST markup. </p>
+<p><p>Some code example:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="nb">int</span> <span class="n">example</span><span class="p">(</span><span class="nb">int</span> <span class="n">x</span><span class="p">)</span> <span class="p">{</span>
+    <span class="k">return</span> <span class="n">x</span> <span class="o">*</span> <span class="mi">2</span><span class="p">;</span>
+<span class="p">}</span>
 </pre></div>
 </div>
+</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Thanks to <a class="reference external" href="https://breathe.readthedocs.io/en/latest/">Breathe</a>, we were able to bring it to <a class="reference external" href="https://www.doxygen.nl/index.html">Doxygen</a></p>
 </div>
+</dd></dl>
+
 </section>
 </section>
 <section id="feeding-doxygen">
@@ -912,7 +909,7 @@ to see it in action.</p>
 It takes the standard project, path, outline and no-link options and
 additionally the members, protected-members, private-members, undoc-members,
 membergroups and members-only options:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">..</span> <span class="n">doxygenclass</span><span class="p">::</span> <span class="o">&lt;</span><span class="k">class</span> <span class="nc">name</span><span class="o">&gt;</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">..</span> <span class="n">doxygenclass</span><span class="p">::</span> <span class="o">&lt;</span><span class="k">class</span><span class="w"> </span><span class="nc">name</span><span class="o">&gt;</span>
    <span class="p">:</span><span class="n">members</span><span class="p">:</span> <span class="p">[</span><span class="o">...</span><span class="p">]</span>
    <span class="p">:</span><span class="n">protected</span><span class="o">-</span><span class="n">members</span><span class="p">:</span>
    <span class="p">:</span><span class="n">private</span><span class="o">-</span><span class="n">members</span><span class="p">:</span>
@@ -1044,7 +1041,8 @@ website explains how to present ideas effectively.</p></li>
             
             
               
-                <div class="bd-sidebar-secondary bd-toc"><div class="sidebar-secondary-items sidebar-secondary__inner">
+                <dialog id="pst-secondary-sidebar-modal"></dialog>
+                <div id="pst-secondary-sidebar" class="bd-sidebar-secondary bd-toc"><div class="sidebar-secondary-items sidebar-secondary__inner">
 
 
   <div class="sidebar-secondary-item">
@@ -1070,15 +1068,17 @@ website explains how to present ideas effectively.</p></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#docstring-intro">Docstrings</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#documenting-c-c-code">Documenting C/C++ code</a><ul class="nav section-nav flex-column">
 <li class="toc-h4 nav-item toc-entry"><a class="reference internal nav-link" href="#writing-the-comment-blocks">1. Writing the comment blocks</a><ul class="nav section-nav flex-column">
-<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo</span></code></a><ul class="nav section-nav flex-column">
-<li class="toc-h6 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo9DoxyLimboEv"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo::DoxyLimbo</span></code></a></li>
-<li class="toc-h6 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo::DoxyLimbo</span></code></a></li>
-<li class="toc-h6 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo4dataEv"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo::data</span></code></a></li>
-<li class="toc-h6 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo6p_dataE"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo::p_data</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv420doxy_javadoc_exampleiPKc"><code class="docutils literal notranslate"><span class="pre">doxy_javadoc_example()</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo9DoxyLimboEv"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo()</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo()</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo4dataEv"><code class="docutils literal notranslate"><span class="pre">data()</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo6p_dataE"><code class="docutils literal notranslate"><span class="pre">p_data</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#common-doxygen-tags">Common Doxygen Tags:</a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#example">Example</a><ul class="nav section-nav flex-column">
+<li class="toc-h6 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv417doxy_reST_examplev"><code class="docutils literal notranslate"><span class="pre">doxy_reST_example()</span></code></a></li>
 </ul>
 </li>
-<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#common-doxygen-tags">Common Doxygen Tags:</a></li>
-<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#example">Example</a></li>
 </ul>
 </li>
 <li class="toc-h4 nav-item toc-entry"><a class="reference internal nav-link" href="#feeding-doxygen">2. Feeding Doxygen</a></li>

--- a/2.2/dev/howto-docs.html
+++ b/2.2/dev/howto-docs.html
@@ -666,10 +666,24 @@ existing non-indexed comment blocks.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenfunction: Cannot find file: /home/matti/oss/numpy/doc/build/doxygen/xml/index.xml</p>
-</div>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv420doxy_javadoc_exampleiPKc">
+<span id="_CPPv320doxy_javadoc_exampleiPKc"></span><span id="_CPPv220doxy_javadoc_exampleiPKc"></span><span id="doxy_javadoc_example__i.cCP"></span><span class="target" id="doxy__func_8h_1a4d3bfb60ef84efac3a58233ab1211795"></span><span class="kt"><span class="pre">int</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">doxy_javadoc_example</span></span></span><span class="sig-paren">(</span><span class="kt"><span class="pre">int</span></span><span class="w"> </span><span class="n sig-param"><span class="pre">num</span></span>, <span class="k"><span class="pre">const</span></span><span class="w"> </span><span class="kt"><span class="pre">char</span></span><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="n sig-param"><span class="pre">str</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv420doxy_javadoc_exampleiPKc" title="Link to this definition">#</a><br /></dt>
+<dd><p>This a simple brief. </p>
+<p>And the details goes here. Multi lines are welcome.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>num</strong> – leave a comment for parameter num. </p></li>
+<li><p><strong>str</strong> – leave a comment for the second parameter. </p></li>
+</ul>
+</dd>
+<dt class="field-even">Returns<span class="colon">:</span></dt>
+<dd class="field-even"><p>leave a comment for the returned value. </p>
+</dd>
+</dl>
+</dd></dl>
+
 <p><strong>For line comment, you can use a triple forward slash. For example</strong>:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">/**</span>
  <span class="o">*</span>  <span class="n">Template</span> <span class="n">to</span> <span class="n">represent</span> <span class="n">limbo</span> <span class="n">numbers</span><span class="o">.</span>
@@ -681,7 +695,7 @@ existing non-indexed comment blocks.</p>
  <span class="o">*</span>  <span class="nd">@param</span> <span class="n">N</span>  <span class="n">Number</span> <span class="n">of</span> <span class="n">elements</span><span class="o">.</span>
 <span class="o">*/</span>
 <span class="n">template</span><span class="o">&lt;</span><span class="n">typename</span> <span class="n">Tp</span><span class="p">,</span> <span class="n">std</span><span class="p">::</span><span class="n">size_t</span> <span class="n">N</span><span class="o">&gt;</span>
-<span class="k">class</span> <span class="nc">DoxyLimbo</span> <span class="p">{</span>
+<span class="k">class</span><span class="w"> </span><span class="nc">DoxyLimbo</span> <span class="p">{</span>
  <span class="n">public</span><span class="p">:</span>
     <span class="o">///</span> <span class="n">Default</span> <span class="n">constructor</span><span class="o">.</span> <span class="n">Initialize</span> <span class="n">nothing</span><span class="o">.</span>
     <span class="n">DoxyLimbo</span><span class="p">();</span>
@@ -695,10 +709,51 @@ existing non-indexed comment blocks.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenclass: Cannot find file: /home/matti/oss/numpy/doc/build/doxygen/xml/index.xml</p>
+<dl class="cpp class">
+<dt class="sig sig-object cpp" id="_CPPv4I0_NSt6size_tEE9DoxyLimbo">
+<span id="_CPPv3I0_NSt6size_tEE9DoxyLimbo"></span><span id="_CPPv2I0_NSt6size_tEE9DoxyLimbo"></span><span class="k"><span class="pre">template</span></span><span class="p"><span class="pre">&lt;</span></span><span class="k"><span class="pre">typename</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">Tp</span></span></span><span class="p"><span class="pre">,</span></span><span class="w"> </span><span class="n"><span class="pre">std</span></span><span class="p"><span class="pre">::</span></span><span class="n"><span class="pre">size_t</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">N</span></span></span><span class="p"><span class="pre">&gt;</span></span><br /><span class="target" id="classDoxyLimbo"></span><span class="k"><span class="pre">class</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><a class="headerlink" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="Link to this definition">#</a><br /></dt>
+<dd><p>Template to represent limbo numbers. </p>
+<p>Specializations for integer types that are part of nowhere. It doesn’t support with any real types.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Param Tp<span class="colon">:</span></dt>
+<dd class="field-odd"><p>Type of the integer. Required to be an integer type. </p>
+</dd>
+<dt class="field-even">Param N<span class="colon">:</span></dt>
+<dd class="field-even"><p>Number of elements. </p>
+</dd>
+</dl>
+<div class="breathe-sectiondef docutils container">
+<p class="breathe-sectiondef-title rubric" id="breathe-section-title-public-functions">Public Functions</p>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv4N9DoxyLimbo9DoxyLimboEv">
+<span id="_CPPv3N9DoxyLimbo9DoxyLimboEv"></span><span id="_CPPv2N9DoxyLimbo9DoxyLimboEv"></span><span id="DoxyLimbo::DoxyLimbo"></span><span class="target" id="classDoxyLimbo_1a9b76dccbb1e8dbbbb46a2f0dbe8909e0"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv4N9DoxyLimbo9DoxyLimboEv" title="Link to this definition">#</a><br /></dt>
+<dd><p>Default constructor. Initialize nothing. </p>
+</dd></dl>
+
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE">
+<span id="_CPPv3N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE"></span><span id="_CPPv2N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE"></span><span id="DoxyLimbo::DoxyLimbo__DoxyLimbo:Tp.N:CR"></span><span class="target" id="classDoxyLimbo_1ae0090b4f0dda7e97c44a4d2a5fac7786"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE" title="DoxyLimbo::DoxyLimbo"><span class="n"><span class="pre">DoxyLimbo</span></span></a><span class="p"><span class="pre">&lt;</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="p"><span class="pre">,</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">&gt;</span></span><span class="w"> </span><span class="p"><span class="pre">&amp;</span></span><span class="n sig-param"><span class="pre">l</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE" title="Link to this definition">#</a><br /></dt>
+<dd><p>Set Default behavior for copy the limbo. </p>
+</dd></dl>
+
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv4N9DoxyLimbo4dataEv">
+<span id="_CPPv3N9DoxyLimbo4dataEv"></span><span id="_CPPv2N9DoxyLimbo4dataEv"></span><span id="DoxyLimbo::data"></span><span class="target" id="classDoxyLimbo_1a7a413dc51bfa468b1958762d17615c81"></span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="sig-name descname"><span class="n"><span class="pre">data</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv4N9DoxyLimbo4dataEv" title="Link to this definition">#</a><br /></dt>
+<dd><p>Returns the raw data for the limbo. </p>
+</dd></dl>
+
 </div>
+<div class="breathe-sectiondef docutils container">
+<p class="breathe-sectiondef-title rubric" id="breathe-section-title-protected-attributes">Protected Attributes</p>
+<dl class="cpp var">
+<dt class="sig sig-object cpp" id="_CPPv4N9DoxyLimbo6p_dataE">
+<span id="_CPPv3N9DoxyLimbo6p_dataE"></span><span id="_CPPv2N9DoxyLimbo6p_dataE"></span><span id="DoxyLimbo::p_data__TpA"></span><span class="target" id="classDoxyLimbo_1a097c2d3d62ef8696ca0f4f9af875be48"></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">p_data</span></span></span><span class="p"><span class="pre">[</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">]</span></span><a class="headerlink" href="#_CPPv4N9DoxyLimbo6p_dataE" title="Link to this definition">#</a><br /></dt>
+<dd><p>Example for inline comment. </p>
+</dd></dl>
+
+</div>
+</dd></dl>
+
 <section id="common-doxygen-tags">
 <h5>Common Doxygen Tags:<a class="headerlink" href="#common-doxygen-tags" title="Link to this heading">#</a></h5>
 <div class="admonition note">
@@ -749,10 +804,23 @@ It is interpreted as source code.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenfunction: Cannot find file: /home/matti/oss/numpy/doc/build/doxygen/xml/index.xml</p>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv417doxy_reST_examplev">
+<span id="_CPPv317doxy_reST_examplev"></span><span id="_CPPv217doxy_reST_examplev"></span><span id="doxy_reST_example__void"></span><span class="target" id="doxy__rst_8h_1a233bf6c1f71e836f3e5b8bd078ca12ec"></span><span class="kt"><span class="pre">void</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">doxy_reST_example</span></span></span><span class="sig-paren">(</span><span class="kt"><span class="pre">void</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv417doxy_reST_examplev" title="Link to this definition">#</a><br /></dt>
+<dd><p>A comment block contains reST markup. </p>
+<p><p>Some code example:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="nb">int</span> <span class="n">example</span><span class="p">(</span><span class="nb">int</span> <span class="n">x</span><span class="p">)</span> <span class="p">{</span>
+    <span class="k">return</span> <span class="n">x</span> <span class="o">*</span> <span class="mi">2</span><span class="p">;</span>
+<span class="p">}</span>
+</pre></div>
 </div>
+</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Thanks to <a class="reference external" href="https://breathe.readthedocs.io/en/latest/">Breathe</a>, we were able to bring it to <a class="reference external" href="https://www.doxygen.nl/index.html">Doxygen</a></p>
+</div>
+</dd></dl>
+
 </section>
 </section>
 <section id="feeding-doxygen">
@@ -808,7 +876,7 @@ to see it in action.</p>
 It takes the standard project, path, outline and no-link options and
 additionally the members, protected-members, private-members, undoc-members,
 membergroups and members-only options:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">..</span> <span class="n">doxygenclass</span><span class="p">::</span> <span class="o">&lt;</span><span class="k">class</span> <span class="nc">name</span><span class="o">&gt;</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">..</span> <span class="n">doxygenclass</span><span class="p">::</span> <span class="o">&lt;</span><span class="k">class</span><span class="w"> </span><span class="nc">name</span><span class="o">&gt;</span>
    <span class="p">:</span><span class="n">members</span><span class="p">:</span> <span class="p">[</span><span class="o">...</span><span class="p">]</span>
    <span class="p">:</span><span class="n">protected</span><span class="o">-</span><span class="n">members</span><span class="p">:</span>
    <span class="p">:</span><span class="n">private</span><span class="o">-</span><span class="n">members</span><span class="p">:</span>
@@ -967,8 +1035,17 @@ website explains how to present ideas effectively.</p></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#docstring-intro">Docstrings</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#documenting-c-c-code">Documenting C/C++ code</a><ul class="nav section-nav flex-column">
 <li class="toc-h4 nav-item toc-entry"><a class="reference internal nav-link" href="#writing-the-comment-blocks">1. Writing the comment blocks</a><ul class="nav section-nav flex-column">
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv420doxy_javadoc_exampleiPKc"><code class="docutils literal notranslate"><span class="pre">doxy_javadoc_example()</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo9DoxyLimboEv"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo()</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo()</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo4dataEv"><code class="docutils literal notranslate"><span class="pre">data()</span></code></a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo6p_dataE"><code class="docutils literal notranslate"><span class="pre">p_data</span></code></a></li>
 <li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#common-doxygen-tags">Common Doxygen Tags:</a></li>
-<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#example">Example</a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#example">Example</a><ul class="nav section-nav flex-column">
+<li class="toc-h6 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv417doxy_reST_examplev"><code class="docutils literal notranslate"><span class="pre">doxy_reST_example()</span></code></a></li>
+</ul>
+</li>
 </ul>
 </li>
 <li class="toc-h4 nav-item toc-entry"><a class="reference internal nav-link" href="#feeding-doxygen">2. Feeding Doxygen</a></li>

--- a/2.3/dev/howto-docs.html
+++ b/2.3/dev/howto-docs.html
@@ -678,17 +678,24 @@ existing non-indexed comment blocks.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenfunction: Unable to resolve function “doxy_javadoc_example” with arguments None in doxygen xml output for project “numpy” from directory: ../build/doxygen/xml.
-Potential matches:
-</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">-</span> <span class="nb">int</span> <span class="n">doxy_javadoc_example</span><span class="p">(</span><span class="nb">int</span> <span class="n">num</span><span class="p">,</span> <span class="n">const</span> <span class="n">char</span> <span class="o">*</span><span class="nb">str</span><span class="p">)</span>
-<span class="o">-</span> <span class="nb">int</span> <span class="n">doxy_javadoc_example</span><span class="p">(</span><span class="nb">int</span> <span class="n">num</span><span class="p">,</span> <span class="n">const</span> <span class="n">char</span> <span class="o">*</span><span class="nb">str</span><span class="p">)</span>
-<span class="o">-</span> <span class="nb">int</span> <span class="n">doxy_javadoc_example</span><span class="p">(</span><span class="nb">int</span> <span class="n">num</span><span class="p">,</span> <span class="n">const</span> <span class="n">char</span> <span class="o">*</span><span class="nb">str</span><span class="p">)</span>
-</pre></div>
-</div>
-</div>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv420doxy_javadoc_exampleiPKc">
+<span id="_CPPv320doxy_javadoc_exampleiPKc"></span><span id="_CPPv220doxy_javadoc_exampleiPKc"></span><span id="doxy_javadoc_example__i.cCP"></span><span class="target" id="doxy__func_8h_1a4d3bfb60ef84efac3a58233ab1211795"></span><span class="kt"><span class="pre">int</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">doxy_javadoc_example</span></span></span><span class="sig-paren">(</span><span class="kt"><span class="pre">int</span></span><span class="w"> </span><span class="n sig-param"><span class="pre">num</span></span>, <span class="k"><span class="pre">const</span></span><span class="w"> </span><span class="kt"><span class="pre">char</span></span><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="n sig-param"><span class="pre">str</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv420doxy_javadoc_exampleiPKc" title="Link to this definition">#</a><br /></dt>
+<dd><p>This a simple brief. </p>
+<p>And the details goes here. Multi lines are welcome.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>num</strong> – leave a comment for parameter num. </p></li>
+<li><p><strong>str</strong> – leave a comment for the second parameter. </p></li>
+</ul>
+</dd>
+<dt class="field-even">Returns<span class="colon">:</span></dt>
+<dd class="field-even"><p>leave a comment for the returned value. </p>
+</dd>
+</dl>
+</dd></dl>
+
 <p><strong>For line comment, you can use a triple forward slash. For example</strong>:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">/**</span>
  <span class="o">*</span>  <span class="n">Template</span> <span class="n">to</span> <span class="n">represent</span> <span class="n">limbo</span> <span class="n">numbers</span><span class="o">.</span>
@@ -747,48 +754,12 @@ Potential matches:
 <dd><p>Returns the raw data for the limbo. </p>
 </dd></dl>
 
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a9b76dccbb1e8dbbbb46a2f0dbe8909e0"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Default constructor. Initialize nothing. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1ae0090b4f0dda7e97c44a4d2a5fac7786"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE" title="DoxyLimbo::DoxyLimbo"><span class="n"><span class="pre">DoxyLimbo</span></span></a><span class="p"><span class="pre">&lt;</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="p"><span class="pre">,</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">&gt;</span></span><span class="w"> </span><span class="p"><span class="pre">&amp;</span></span><span class="n sig-param"><span class="pre">l</span></span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Set Default behavior for copy the limbo. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a7a413dc51bfa468b1958762d17615c81"></span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="sig-name descname"><span class="n"><span class="pre">data</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Returns the raw data for the limbo. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a9b76dccbb1e8dbbbb46a2f0dbe8909e0"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Default constructor. Initialize nothing. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1ae0090b4f0dda7e97c44a4d2a5fac7786"></span><span class="sig-name descname"><span class="n"><span class="pre">DoxyLimbo</span></span></span><span class="sig-paren">(</span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE" title="DoxyLimbo::DoxyLimbo"><span class="n"><span class="pre">DoxyLimbo</span></span></a><span class="p"><span class="pre">&lt;</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="p"><span class="pre">,</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">&gt;</span></span><span class="w"> </span><span class="p"><span class="pre">&amp;</span></span><span class="n sig-param"><span class="pre">l</span></span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Set Default behavior for copy the limbo. </p>
-</dd></dl>
-
-<dl class="cpp function">
-<dt class="sig sig-object cpp">
-<span class="target" id="classDoxyLimbo_1a7a413dc51bfa468b1958762d17615c81"></span><span class="k"><span class="pre">const</span></span><span class="w"> </span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="p"><span class="pre">*</span></span><span class="sig-name descname"><span class="n"><span class="pre">data</span></span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><br /></dt>
-<dd><p>Returns the raw data for the limbo. </p>
-</dd></dl>
-
 </div>
 <div class="breathe-sectiondef docutils container">
 <p class="breathe-sectiondef-title rubric" id="breathe-section-title-protected-attributes">Protected Attributes</p>
 <dl class="cpp var">
 <dt class="sig sig-object cpp" id="_CPPv4N9DoxyLimbo6p_dataE">
-<span id="_CPPv3N9DoxyLimbo6p_dataE"></span><span id="_CPPv2N9DoxyLimbo6p_dataE"></span><span id="DoxyLimbo::p_data__TpA"></span><span class="target" id="classDoxyLimbo_1a952dd83b3eeb92013adcf2c065a98b77"></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">p_data</span></span></span><span class="p"><span class="pre">[</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">]</span></span><a class="headerlink" href="#_CPPv4N9DoxyLimbo6p_dataE" title="Link to this definition">#</a><br /></dt>
+<span id="_CPPv3N9DoxyLimbo6p_dataE"></span><span id="_CPPv2N9DoxyLimbo6p_dataE"></span><span id="DoxyLimbo::p_data__TpA"></span><span class="target" id="classDoxyLimbo_1a097c2d3d62ef8696ca0f4f9af875be48"></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::Tp"><span class="n"><span class="pre">Tp</span></span></a><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">p_data</span></span></span><span class="p"><span class="pre">[</span></span><a class="reference internal" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo" title="DoxyLimbo::N"><span class="n"><span class="pre">N</span></span></a><span class="p"><span class="pre">]</span></span><a class="headerlink" href="#_CPPv4N9DoxyLimbo6p_dataE" title="Link to this definition">#</a><br /></dt>
 <dd><p>Example for inline comment. </p>
 </dd></dl>
 
@@ -845,17 +816,23 @@ It is interpreted as source code.</p>
 </pre></div>
 </div>
 <p><strong>And here is how it is rendered</strong>:</p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>doxygenfunction: Unable to resolve function “doxy_reST_example” with arguments None in doxygen xml output for project “numpy” from directory: ../build/doxygen/xml.
-Potential matches:
-</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">-</span> <span class="n">void</span> <span class="n">doxy_reST_example</span><span class="p">(</span><span class="n">void</span><span class="p">)</span>
-<span class="o">-</span> <span class="n">void</span> <span class="n">doxy_reST_example</span><span class="p">(</span><span class="n">void</span><span class="p">)</span>
-<span class="o">-</span> <span class="n">void</span> <span class="n">doxy_reST_example</span><span class="p">(</span><span class="n">void</span><span class="p">)</span>
+<dl class="cpp function">
+<dt class="sig sig-object cpp" id="_CPPv417doxy_reST_examplev">
+<span id="_CPPv317doxy_reST_examplev"></span><span id="_CPPv217doxy_reST_examplev"></span><span id="doxy_reST_example__void"></span><span class="target" id="doxy__rst_8h_1a233bf6c1f71e836f3e5b8bd078ca12ec"></span><span class="kt"><span class="pre">void</span></span><span class="w"> </span><span class="sig-name descname"><span class="n"><span class="pre">doxy_reST_example</span></span></span><span class="sig-paren">(</span><span class="kt"><span class="pre">void</span></span><span class="sig-paren">)</span><a class="headerlink" href="#_CPPv417doxy_reST_examplev" title="Link to this definition">#</a><br /></dt>
+<dd><p>A comment block contains reST markup. </p>
+<p><p>Some code example:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="nb">int</span> <span class="n">example</span><span class="p">(</span><span class="nb">int</span> <span class="n">x</span><span class="p">)</span> <span class="p">{</span>
+    <span class="k">return</span> <span class="n">x</span> <span class="o">*</span> <span class="mi">2</span><span class="p">;</span>
+<span class="p">}</span>
 </pre></div>
 </div>
+</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Thanks to <a class="reference external" href="https://breathe.readthedocs.io/en/latest/">Breathe</a>, we were able to bring it to <a class="reference external" href="https://www.doxygen.nl/index.html">Doxygen</a></p>
 </div>
+</dd></dl>
+
 </section>
 </section>
 <section id="feeding-doxygen">
@@ -1070,13 +1047,17 @@ website explains how to present ideas effectively.</p></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#docstring-intro">Docstrings</a></li>
 <li class="toc-h3 nav-item toc-entry"><a class="reference internal nav-link" href="#documenting-c-c-code">Documenting C/C++ code</a><ul class="nav section-nav flex-column">
 <li class="toc-h4 nav-item toc-entry"><a class="reference internal nav-link" href="#writing-the-comment-blocks">1. Writing the comment blocks</a><ul class="nav section-nav flex-column">
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv420doxy_javadoc_exampleiPKc"><code class="docutils literal notranslate"><span class="pre">doxy_javadoc_example()</span></code></a></li>
 <li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4I0_NSt6size_tEE9DoxyLimbo"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo</span></code></a></li>
 <li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo9DoxyLimboEv"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo()</span></code></a></li>
 <li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo9DoxyLimboERK9DoxyLimboI2Tp1NE"><code class="docutils literal notranslate"><span class="pre">DoxyLimbo()</span></code></a></li>
 <li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo4dataEv"><code class="docutils literal notranslate"><span class="pre">data()</span></code></a></li>
 <li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv4N9DoxyLimbo6p_dataE"><code class="docutils literal notranslate"><span class="pre">p_data</span></code></a></li>
 <li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#common-doxygen-tags">Common Doxygen Tags:</a></li>
-<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#example">Example</a></li>
+<li class="toc-h5 nav-item toc-entry"><a class="reference internal nav-link" href="#example">Example</a><ul class="nav section-nav flex-column">
+<li class="toc-h6 nav-item toc-entry"><a class="reference internal nav-link" href="#_CPPv417doxy_reST_examplev"><code class="docutils literal notranslate"><span class="pre">doxy_reST_example()</span></code></a></li>
+</ul>
+</li>
 </ul>
 </li>
 <li class="toc-h4 nav-item toc-entry"><a class="reference internal nav-link" href="#feeding-doxygen">2. Feeding Doxygen</a></li>


### PR DESCRIPTION
Closes numpy/numpy#29274 by copying the relevant parts of the page from the devdocs build. numpy/numpy#29275 will prevent this going forward

Maybe we should only fix the latest version? No-one complained about the earlier ones...