### PR TITLE
MAINT: Link the logo to numpy.org instead of docs site

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <body>
 <div class="container">
   <div class="top-scipy-org-logo-header" style="background-color: #ffffff;">
-    <a href="#">
+    <a href="https://numpy.org" class="spc-logo-header">
       <img border=0 alt="NumPy" src="_static/numpylogo.svg"></a>
     </div>
   </div>
@@ -51,10 +51,6 @@
 		<div class="span9">
   		  <div class="spc-navbar">
 
-    <ul class="nav nav-pills pull-left">
-        <li class="active"><a href="http://numpy.org/">NumPy.org</a></li>
-
-    </ul>
 		  </div>
 		</div>
 	      </div>


### PR DESCRIPTION
As suggested by @Mukulikaa in https://github.com/numpy/numpy/issues/29543#issuecomment-3181977072 - I think this makes sense, since as she pointed out this header is not really shared with any of the child pages so there's no use in re-linking it to here.