### PR TITLE
Fix dark mode font color for version switcher

### DIFF
--- a/2.4/_static/numpy.css
+++ b/2.4/_static/numpy.css
@@ -28,7 +28,6 @@ body {
 
 button.btn.version-switcher__button,
 button.btn.version-switcher__button:hover {
-  color: black;
   font-size: small;
 }
 


### PR DESCRIPTION
See https://github.com/numpy/numpy/pull/31028 - this fixes the version switcher button font for dark mode in the 2.4 version.

The other items in that PR I don't think need fixing but this item is illegible which has impacts to accessibility and readability.